### PR TITLE
fix ansible.cfg and devbox_setup.yml

### DIFF
--- a/learning_labs/yang/yang-prereqs/ansible.cfg
+++ b/learning_labs/yang/yang-prereqs/ansible.cfg
@@ -4,3 +4,4 @@
 [defaults]
 # default to inventory file of ./hosts
 inventory      = ./hosts
+library        = ./library

--- a/learning_labs/yang/yang-prereqs/devbox_setup.yml
+++ b/learning_labs/yang/yang-prereqs/devbox_setup.yml
@@ -3,6 +3,7 @@
 - name: SET UP YANG DEVBOX ENVIRONMENT
   hosts: devbox
   become: yes
+  gather_facts: no
   tags: devbox
 
   vars:


### PR DESCRIPTION
Fixes for failure of `spine_setup.yml` playbook.:
1. Update ansible.cfg module search path
2. Update devbox_setup.yml to not gather facts - Refer **Common Issues** under https://github.com/networktocode/ntc-ansible