### PR TITLE
update LM1451 for sandbox security

### DIFF
--- a/learning_labs/LM-1451 intro-ansible/ansible-03_ansible-hands-on/hosts-datacenter
+++ b/learning_labs/LM-1451 intro-ansible/ansible-03_ansible-hands-on/hosts-datacenter
@@ -1,8 +1,8 @@
 [sandbox-servers]
-10.10.20.20
+10.10.20.20 ansible_connection=local
 
 [datacenter-east]
-10.10.20.20
+10.10.20.20 ansible_connection=local
 
 [datacenter-west]
-10.10.20.20
+10.10.20.20 ansible_connection=local

--- a/learning_labs/LM-1451 intro-ansible/ansible-03_ansible-hands-on/hosts-groups
+++ b/learning_labs/LM-1451 intro-ansible/ansible-03_ansible-hands-on/hosts-groups
@@ -3,7 +3,7 @@ datacenter-east
 datacenter-west
 
 [datacenter-east]
-10.10.20.20
+10.10.20.20 ansible_connection=local
 
 [datacenter-west]
-10.10.20.20
+10.10.20.20 ansible_connection=local


### PR DESCRIPTION
Updated LM-1451 inventories based on changes to Ansible LL and security posture.
Requires `ansible_connection=local` to not give non-severe warning to stdout.